### PR TITLE
Add package.json & upgrade socket.io

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "club-fair-attention-monopoly",
+  "version": "1.0.0",
+  "description": "I built this app (inspired by [@lachlanjc](https://github.com/lachlanjc)'s own [schacks-demo](https://glitch.com/edit/#!/schacks-demo)) to advertise my [Hack Club](https://hackclub.com) at our schools' club fair, where all the incoming freshman come to sign up for clubs. My goal was simple: attract as much attention as humanly possible. That is what I did.",
+  "main": "server.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "node server.js"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/tmb/club-fair-attention-monopoly.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/tmb/club-fair-attention-monopoly/issues"
+  },
+  "homepage": "https://github.com/tmb/club-fair-attention-monopoly#readme",
+  "dependencies": {
+    "body-parser": "^1.19.0",
+    "express": "^4.17.1",
+    "socket.io": "^4.2.0"
+  }
+}

--- a/views/index.html
+++ b/views/index.html
@@ -2,8 +2,8 @@
 	<title>WHS Hack Club</title>
 
 	<script
-		src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/2.2.0/socket.io.js"
-		integrity="sha256-yr4fRk/GU1ehYJPAs8P4JlTgu0Hdsp4ZKrx8bDEDC3I="
+		src="https://cdnjs.cloudflare.com/ajax/libs/socket.io/4.2.0/socket.io.js"
+		integrity="sha256-rntBe6iTTkeyQOk1rjOUeT3NC3a1/qS1hgz7EyJyGRY="
 		crossorigin="anonymous"
 	></script>
 	<script


### PR DESCRIPTION
I was helping a new club leader set this up for their club fair and discovered that because there was no `package.json` file included, repl.it would generate its own, which would include the latest version of socket.io, which did not match the client's version in `index.html`. This prevented the app from working. Other club leaders had run into this in the past and had spent hours debugging it before they realized the issue. This PR adds a `package.json` file so that future club leaders can make their app work out of the box as intended. It also upgrades socket.io, because why not ¯\\_(ツ)_/¯